### PR TITLE
[proj4] Add proj.pc export

### DIFF
--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -62,7 +62,7 @@ vcpkg_cmake_configure(
         -DBUILD_LIBPROJ_SHARED=${PROJ_SHARED_LIBS}
         -DPROJ_LIB_SUBDIR=lib
         -DPROJ_INCLUDE_SUBDIR=include
-        -DPROJ_DATA_SUBDIR=share/proj4
+        -DPROJ_DATA_SUBDIR=share/proj
         -DBUILD_CCT=OFF
         -DBUILD_CS2CS=OFF
         -DBUILD_GEOD=OFF

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -77,6 +77,21 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/proj4)
 vcpkg_copy_pdbs()
 
+# ➜ Add proj.pc for pkg-config since some dependencies (e.g., libgeotiff) are looking for this
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/pkgconfig/proj.pc" "
+prefix=${CURRENT_PACKAGES_DIR}
+exec_prefix=\\${prefix}
+libdir=\\${prefix}/lib
+includedir=\\${prefix}/include
+
+Name: proj
+Description: PROJ library for cartographic projections
+Version: ${VERSION}
+Libs: -L\\${libdir} -lproj
+Cflags: -I\\${includedir}
+")
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 

--- a/ports/proj4/vcpkg.json
+++ b/ports/proj4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "proj4",
   "version-string": "6.3.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "PROJ.4 library for cartographic projections",
   "homepage": "https://github.com/OSGeo/PROJ",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "proj4": {
       "baseline": "6.3.2",
-      "port-version": 1
+      "port-version": 2
     }
   }
 }

--- a/versions/p-/proj4.json
+++ b/versions/p-/proj4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a275bf82f455d77d42e1fbc2ac20efee69fe617f",
+      "version": "6.3.2",
+      "port-version": 2
+    },
+	{
       "git-tree": "861a58aa07b6218c9d1e576883f1b3d3d0234c5d",
       "version": "6.3.2",
       "port-version": 1

--- a/versions/p-/proj4.json
+++ b/versions/p-/proj4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a275bf82f455d77d42e1fbc2ac20efee69fe617f",
+      "git-tree": "4e80b3b6ba4072d3fe646ae0e44fef5513b1be58",
       "version": "6.3.2",
       "port-version": 2
     },

--- a/versions/p-/proj4.json
+++ b/versions/p-/proj4.json
@@ -5,7 +5,7 @@
       "version": "6.3.2",
       "port-version": 2
     },
-	{
+    {
       "git-tree": "861a58aa07b6218c9d1e576883f1b3d3d0234c5d",
       "version": "6.3.2",
       "port-version": 1


### PR DESCRIPTION
With this PR we ensure that a proj.pc is created which is expected for some dependencies (under certain circumstances). I'm not quite sure why, e.g., `libgeotiff` suddenly expects a `*.pc` file after changing anything in files such as  `vcpkg_configure_cmake.cmake`, but it seems to me like the most straightforward fix.